### PR TITLE
Allowed Query Parameters and Exclusion Regex for Prerendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library to use prerender.io with Play Framework
 
 ``` scala
   val appDependencies = Seq(
-    "net.kaliber" %% "play-prerender" % "0.10"
+    "net.kaliber" %% "play-prerender" % "0.12-SNAPSHOT"
   )
 
   val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(
@@ -29,6 +29,10 @@ prerender.service = "http://localhost:3000/"
 prerender.maximumAttempts = 2
 # If you require a user agent which is not present in the default list it can be added through through this configuration option.
 prerender.additionalAgents = []
+# (Optional) When set, a URI will only be prerendered if its query parameter names are included in the limitedParams configuration option.
+prerender.limitedParams = Option(Set("goodparam", "allowedparam"))
+# (Optional) When set, URIs will not be prerendered if the excludeRegex matches any part of the URI.
+prerender.excludeRegex = Option("2222|1111")
 ```
 
 ### Default user agents

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library to use prerender.io with Play Framework
 
 ``` scala
   val appDependencies = Seq(
-    "net.kaliber" %% "play-prerender" % "0.12"
+    "net.kaliber" %% "play-prerender" % "0.11"
   )
 
   val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library to use prerender.io with Play Framework
 
 ``` scala
   val appDependencies = Seq(
-    "net.kaliber" %% "play-prerender" % "0.12-SNAPSHOT"
+    "net.kaliber" %% "play-prerender" % "0.12"
   )
 
   val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
@@ -53,12 +53,10 @@ case class PrerenderActionBuilders(config: PrerenderConfig)(implicit ec: Executi
     requestParams subsetOf config.limitedParams.getOrElse(requestParams)
   }
 
-  private def isExcludedWithRegex(request: RequestHeader) = {
-    config.excludeRegex.getOrElse("").r.findFirstMatchIn(request.uri) match {
-      case None => false
-      case Some(matchingSubstring) => !matchingSubstring.toString().isEmpty
-    }
-  }
+  private def isExcludedWithRegex(request: RequestHeader) =
+    config.excludeRegex
+      .flatMap(_.r.findFirstMatchIn(request.uri))
+      .isDefined
 
   private def isEscapedFragmentUrl(request: RequestHeader) =
     request.queryString.contains("_escaped_fragment_")

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
@@ -1,7 +1,6 @@
 package net.kaliber.play.prerender
 
 import java.net.ConnectException
-import com.google.common.annotations.VisibleForTesting
 import play.api.http.Status.SERVICE_UNAVAILABLE
 import play.api.libs.ws.WSClient
 import play.api.mvc.{ ActionBuilder, Request, RequestHeader, Result }

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
@@ -47,7 +47,7 @@ case class PrerenderActionBuilders(config: PrerenderConfig)(implicit ec: Executi
   private def isSearchEngineRequest(request: RequestHeader) =
     isEscapedFragmentUrl(request) || hasSearchEngineUserAgent(request)
 
-  private def hasOnlyAllowedParams(request: RequestHeader): Boolean = {
+  private def hasOnlyAllowedParams(request: RequestHeader) = {
     val requestParams = request.queryString.keys.toSet
     requestParams subsetOf config.limitedParams.getOrElse(requestParams)
   }

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderActionBuilders.scala
@@ -40,7 +40,8 @@ case class PrerenderActionBuilders(config: PrerenderConfig)(implicit ec: Executi
   }
 
   private def shouldBePrerendered(request: RequestHeader) =
-    config.enabled && isGetRequest(request) && isSearchEngineRequest(request) && hasOnlyAllowedParams(request) && !isExcludedWithRegex(request)
+    config.enabled && isGetRequest(request) && isSearchEngineRequest(request) &&
+    hasOnlyAllowedParams(request) && !isExcludedWithRegex(request)
 
   private def isGetRequest(request: RequestHeader) = request.method == "GET"
 

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
@@ -1,7 +1,5 @@
 package net.kaliber.play.prerender
 
-import play.api.mvc.RequestHeader
-
 
 case class PrerenderConfig(
   enabled: Boolean,

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
@@ -1,10 +1,15 @@
 package net.kaliber.play.prerender
 
+import play.api.mvc.RequestHeader
+
+
 case class PrerenderConfig(
   enabled: Boolean,
   service: String,
   ssl: Boolean,
   token: Option[String] = None,
   maximumAttempts: Int = 1,
-  additionalAgents: Seq[String]
+  additionalAgents: Seq[String],
+  limitedParams: Option[Set[String]] = None,
+  excludeRegex: Option[String] = None
 )

--- a/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
+++ b/src/main/scala/net/kaliber/play/prerender/PrerenderConfig.scala
@@ -1,6 +1,5 @@
 package net.kaliber.play.prerender
 
-
 case class PrerenderConfig(
   enabled: Boolean,
   service: String,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11-SNAPSHOT"
+version in ThisBuild := "0.12-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12-SNAPSHOT"
+version in ThisBuild := "0.11-SNAPSHOT"


### PR DESCRIPTION
These optional configurations allow for more control over which requests get prerendered and which do not. We'll use this for testing purposes and for excluding duplicated pages in the cache that contain extraneous query params.
